### PR TITLE
Add map placeholder and scripts to contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -28,6 +28,7 @@
       <p>Bazhdarhane Pn<br>Zip: 20000<br>Phone: <a href="tel:0038349229997">0038349229997</a><br>Email: <a href="mailto:info@optixcom.net">info@optixcom.net</a></p>
     </div>
   </div>
+  <div id="map"></div>
   <form id="contactForm" class="form" method="post" action="/api/contact">
     <div class="field">
       <label for="name">Name*</label>
@@ -71,6 +72,8 @@
   </div>
   <div class="footer__legal">© <span id="y"></span> Optixcom. All rights reserved.</div>
 </footer>
+<script src="/js/mapdata.js"></script>
+<script src="/js/countrymap.js"></script>
 <script src="/main.js" defer></script>
 </body>
 </html>

--- a/js/countrymap.js
+++ b/js/countrymap.js
@@ -1,0 +1,24 @@
+// Placeholder implementation for country map rendering.
+// This script populates the #map div with location data from mapdata.js.
+
+(function() {
+  function initMap() {
+    var mapDiv = document.getElementById('map');
+    var data = window.simplemaps_countrymap_mapdata;
+    if (!mapDiv || !data || !data.locations) return;
+    var list = document.createElement('ul');
+    Object.keys(data.locations).forEach(function(key) {
+      var loc = data.locations[key];
+      var item = document.createElement('li');
+      item.textContent = loc.name + ' (' + loc.lat + ', ' + loc.lng + ')';
+      list.appendChild(item);
+    });
+    mapDiv.appendChild(list);
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initMap);
+  } else {
+    initMap();
+  }
+})();
+


### PR DESCRIPTION
## Summary
- Insert map container on contact page and load map scripts
- Add placeholder `countrymap.js` that lists locations from map data

## Testing
- ⚠️ `playwright install chromium >/tmp/playwright-install.log && tail -n 20 /tmp/playwright-install.log` (403 domain forbidden)
- ⚠️ `python3 - <<'PY'
from pathlib import Path
from playwright.sync_api import sync_playwright

html_path = Path('contact.html').resolve().as_uri()
print('Loading', html_path)
with sync_playwright() as p:
    browser = p.chromium.launch()
    page = browser.new_page()
    page.goto(html_path)
    page.wait_for_selector('#map li')
    text = page.inner_text('#map')
    print('Map text:', text)
    browser.close()
PY` (BrowserType.launch: Executable doesn't exist)


------
https://chatgpt.com/codex/tasks/task_e_68c818c34bfc8324b3c9855f560c6bdd