### PR TITLE
Add European locations map to contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <link rel="stylesheet" href="/styles.css">
   <link rel="icon" href="/public/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <script src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js" defer></script>
 </head>
 <body>
@@ -29,6 +30,11 @@
       <p>Bazhdarhane Pn<br>Zip: 20000<br>Phone: <a href="tel:0038349229997">0038349229997</a><br>Email: <a href="mailto:info@optixcom.net">info@optixcom.net</a></p>
     </div>
   </div>
+  <section class="map-section" aria-label="Map of Optixcom locations in Europe">
+    <h2>Our European presence</h2>
+    <p class="map-section__intro">Explore the key cities where Optixcom operates across Europe.</p>
+    <div id="coverageMap" class="map" role="application" aria-label="European map with Optixcom locations"></div>
+  </section>
 <!--  <div class="hero__media">-->
 <!--      <lottie-player src="/public/Red Network Globe.json" background="transparent" speed="1" loop autoplay></lottie-player>-->
 <!--  </div>-->
@@ -75,6 +81,7 @@
   </div>
   <div class="footer__legal">© <span id="y"></span> Optixcom. All rights reserved.</div>
 </footer>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="" defer></script>
 <script src="/main.js" defer></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -40,4 +40,28 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  // Leaflet map of European locations
+  const mapEl = document.getElementById('coverageMap');
+  if (mapEl && window.L) {
+    const map = L.map(mapEl, {scrollWheelZoom: false});
+    const locations = [
+      {name: 'Tirana, Albania', coords: [41.3275, 19.8187], note: 'Head office'},
+      {name: 'Prishtina, Kosovo', coords: [42.6629, 21.1655]},
+      {name: 'Bulgaria', coords: [42.7339, 25.4858]},
+      {name: 'Slovenia', coords: [46.1512, 14.9955]},
+      {name: 'Frankfurt, Germany', coords: [50.1109, 8.6821]}
+    ];
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors'
+    }).addTo(map);
+
+    const bounds = L.latLngBounds(locations.map((loc) => loc.coords));
+    locations.forEach((loc) => {
+      const content = `<strong>${loc.name}</strong>${loc.note ? `<br>${loc.note}` : ''}`;
+      L.marker(loc.coords).addTo(map).bindPopup(content);
+    });
+    map.fitBounds(bounds, {padding: [30, 30]});
+  }
 });

--- a/styles.css
+++ b/styles.css
@@ -75,6 +75,10 @@ input:focus,textarea:focus{border-color:var(--acc);box-shadow:0 0 0 .2rem var(--
 
 /* contact locations */
 .locations{display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:2rem}
+.map-section{background:var(--card);border:1px solid #1b2635;border-radius:.8rem;padding:1.2rem;margin-bottom:2rem}
+.map-section h2{margin-top:.2rem}
+.map-section__intro{margin:0 0 1rem;color:var(--muted)}
+.map{height:400px;border-radius:.6rem;overflow:hidden}
 
 @media (max-width:900px){
   .hero{grid-template-columns:1fr}
@@ -82,6 +86,7 @@ input:focus,textarea:focus{border-color:var(--acc);box-shadow:0 0 0 .2rem var(--
   .footprint{grid-template-columns:1fr}
   .testimonials__wrap{grid-template-columns:1fr}
   .locations{grid-template-columns:1fr}
+  .map{height:320px}
   .nav-toggle{display:inline-block}
   .site-nav{display:none}
   .site-nav.is-open{display:flex;flex-direction:column;position:absolute;top:60px;right:12px;background:#0f1622;border:1px solid #1b2635;border-radius:.6rem;padding:.6rem}


### PR DESCRIPTION
## Summary
- add a Leaflet-powered map on the contact page to highlight Optixcom's European presence
- style the new map section so it blends with existing design and works on small screens
- initialize map markers for Tirana, Prishtina, Bulgaria, Slovenia, and Frankfurt

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2badfcc4483249b72a49d36d2d3aa