### PR TITLE
Add MikroTik PPPoE RADIUS Manager: Laravel backend, FreeRADIUS schema, migrations and React UI starters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
-# Optixcom
+# MikroTik PPPoE Radius Manager
 
-Website for Optixcom, an international telecommunication company providing Internet connectivity and project-oriented services.
+This repository now includes a production-ready architecture blueprint and starter implementation for a DMA Softlab Radius Manager-like system:
 
-Deploy this site on Cloudflare Pages.
+- **Backend**: Laravel API (role-aware admin + PPPoE management + billing + logs)
+- **Frontend**: React + Tailwind pages for dashboard and operations
+- **Auth Source of Truth**: Local DB + FreeRADIUS SQL tables
+- **Router Behavior**: MikroTik as PPPoE NAS only (no PPP secrets on router)
+
+## Architecture
+
+Web Panel → Local Database → FreeRADIUS → MikroTik PPPoE Server
+
+## Implemented Core Building Blocks
+
+- API route skeletons for auth, dashboard, clients, packages, NAS, renewals, payments.
+- Migrations for business data plus FreeRADIUS SQL schema.
+- Radius sync service that writes `radcheck` + `radusergroup` and can force reject disabled users.
+- React dashboard and PPPoE clients page starters.
+- Ubuntu installation and integration guide.
+
+## Next Steps
+
+1. Run full Laravel install in `backend` and wire controllers/resources/policies.
+2. Add React router/forms/tables and authentication UI.
+3. Add scheduled command for expiry automation and logging.
+4. Add tests (feature + integration) for Radius sync and renew flow.
+
+See `docs/SETUP_UBUNTU.md` for full setup flow.

--- a/backend/app/Http/Controllers/Api/PppoeClientController.php
+++ b/backend/app/Http/Controllers/Api/PppoeClientController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\PppoeClient;
+use App\Services\RadiusSyncService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+
+class PppoeClientController extends Controller
+{
+    public function __construct(private RadiusSyncService $radiusSyncService) {}
+
+    public function index()
+    {
+        return PppoeClient::with('package')->latest()->paginate(25);
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'full_name' => ['required', 'string', 'max:255'],
+            'username' => ['required', 'string', 'max:64', 'unique:pppoe_clients,username'],
+            'password' => ['required', 'string', 'min:6', 'max:72'],
+            'package_id' => ['required', 'exists:packages,id'],
+            'expiry_date' => ['required', 'date'],
+            'phone' => ['nullable', 'string', 'max:30'],
+            'address' => ['nullable', 'string'],
+            'comment' => ['nullable', 'string'],
+        ]);
+
+        $client = PppoeClient::create([
+            ...$validated,
+            'password' => encrypt($validated['password']),
+            'status' => 'active',
+        ]);
+
+        $this->radiusSyncService->syncClient($client, $validated['password']);
+
+        return response()->json($client->load('package'), 201);
+    }
+
+    public function disable(PppoeClient $client)
+    {
+        $client->update(['status' => 'disabled']);
+        $this->radiusSyncService->disableClient($client->username);
+        return response()->json(['message' => 'Client disabled']);
+    }
+}

--- a/backend/app/Models/Package.php
+++ b/backend/app/Models/Package.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Package extends Model
+{
+    protected $fillable = [
+        'name',
+        'download_kbps',
+        'upload_kbps',
+        'price',
+        'validity_days',
+        'radius_group',
+        'radius_attributes',
+    ];
+
+    protected $casts = [
+        'radius_attributes' => 'array',
+    ];
+}

--- a/backend/app/Models/PppoeClient.php
+++ b/backend/app/Models/PppoeClient.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PppoeClient extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'full_name',
+        'username',
+        'password',
+        'phone',
+        'address',
+        'package_id',
+        'expiry_date',
+        'status',
+        'comment',
+    ];
+
+    protected $casts = [
+        'expiry_date' => 'date',
+    ];
+
+    public function package()
+    {
+        return $this->belongsTo(Package::class);
+    }
+}

--- a/backend/app/Services/RadiusSyncService.php
+++ b/backend/app/Services/RadiusSyncService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\PppoeClient;
+use Illuminate\Support\Facades\DB;
+
+class RadiusSyncService
+{
+    public function syncClient(PppoeClient $client, string $plainPassword): void
+    {
+        DB::table('radcheck')->where('username', $client->username)->delete();
+        DB::table('radcheck')->insert([
+            'username' => $client->username,
+            'attribute' => 'Cleartext-Password',
+            'op' => ':=',
+            'value' => $plainPassword,
+        ]);
+
+        DB::table('radusergroup')->updateOrInsert(
+            ['username' => $client->username],
+            ['groupname' => $client->package->radius_group, 'priority' => 1]
+        );
+    }
+
+    public function disableClient(string $username): void
+    {
+        DB::table('radcheck')->updateOrInsert(
+            ['username' => $username, 'attribute' => 'Auth-Type'],
+            ['op' => ':=', 'value' => 'Reject']
+        );
+    }
+}

--- a/backend/database/migrations/2026_05_08_000001_create_packages_table.php
+++ b/backend/database/migrations/2026_05_08_000001_create_packages_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::create('packages', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->unsignedInteger('download_kbps');
+            $table->unsignedInteger('upload_kbps');
+            $table->decimal('price', 10, 2);
+            $table->unsignedInteger('validity_days')->default(30);
+            $table->string('radius_group')->unique();
+            $table->json('radius_attributes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void {
+        Schema::dropIfExists('packages');
+    }
+};

--- a/backend/database/migrations/2026_05_08_000002_create_pppoe_clients_table.php
+++ b/backend/database/migrations/2026_05_08_000002_create_pppoe_clients_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::create('pppoe_clients', function (Blueprint $table) {
+            $table->id();
+            $table->string('full_name');
+            $table->string('username')->unique();
+            $table->string('password');
+            $table->string('phone')->nullable();
+            $table->text('address')->nullable();
+            $table->foreignId('package_id')->constrained('packages');
+            $table->date('expiry_date');
+            $table->enum('status', ['active', 'disabled', 'expired'])->default('active');
+            $table->text('comment')->nullable();
+            $table->timestamps();
+            $table->index(['status', 'expiry_date']);
+        });
+    }
+
+    public function down(): void {
+        Schema::dropIfExists('pppoe_clients');
+    }
+};

--- a/backend/database/migrations/2026_05_08_000003_create_billing_and_logs_tables.php
+++ b/backend/database/migrations/2026_05_08_000003_create_billing_and_logs_tables.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('pppoe_client_id')->constrained('pppoe_clients');
+            $table->decimal('amount', 10, 2);
+            $table->string('method')->default('cash');
+            $table->string('reference')->nullable();
+            $table->timestamp('paid_at');
+            $table->timestamps();
+        });
+
+        Schema::create('renewals', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('pppoe_client_id')->constrained('pppoe_clients');
+            $table->foreignId('package_id')->constrained('packages');
+            $table->unsignedInteger('days_added');
+            $table->date('old_expiry_date');
+            $table->date('new_expiry_date');
+            $table->foreignId('performed_by')->constrained('users');
+            $table->timestamps();
+        });
+
+        Schema::create('nas_devices', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('ip_address')->unique();
+            $table->string('secret_encrypted');
+            $table->text('description')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('activity_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained('users');
+            $table->string('action');
+            $table->string('subject_type')->nullable();
+            $table->unsignedBigInteger('subject_id')->nullable();
+            $table->json('meta')->nullable();
+            $table->ipAddress('ip')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void {
+        Schema::dropIfExists('activity_logs');
+        Schema::dropIfExists('nas_devices');
+        Schema::dropIfExists('renewals');
+        Schema::dropIfExists('payments');
+    }
+};

--- a/backend/database/migrations/2026_05_08_000004_create_freeradius_tables.php
+++ b/backend/database/migrations/2026_05_08_000004_create_freeradius_tables.php
@@ -1,0 +1,14 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void {
+        DB::unprepared(file_get_contents(database_path('schema/freeradius.sql')));
+    }
+
+    public function down(): void {
+        DB::unprepared('DROP TABLE IF EXISTS radpostauth, radacct, radgroupcheck, radgroupreply, radreply, radcheck, radusergroup, nas;');
+    }
+};

--- a/backend/database/schema/freeradius.sql
+++ b/backend/database/schema/freeradius.sql
@@ -1,0 +1,73 @@
+CREATE TABLE IF NOT EXISTS radcheck (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(64) NOT NULL,
+  attribute VARCHAR(64) NOT NULL,
+  op CHAR(2) NOT NULL DEFAULT ':=',
+  value VARCHAR(253) NOT NULL,
+  INDEX idx_radcheck_username (username)
+);
+CREATE TABLE IF NOT EXISTS radreply (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(64) NOT NULL,
+  attribute VARCHAR(64) NOT NULL,
+  op CHAR(2) NOT NULL DEFAULT '=',
+  value VARCHAR(253) NOT NULL,
+  INDEX idx_radreply_username (username)
+);
+CREATE TABLE IF NOT EXISTS radusergroup (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(64) NOT NULL,
+  groupname VARCHAR(64) NOT NULL,
+  priority INT NOT NULL DEFAULT 1,
+  UNIQUE KEY uniq_usergroup (username, groupname)
+);
+CREATE TABLE IF NOT EXISTS radgroupreply (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  groupname VARCHAR(64) NOT NULL,
+  attribute VARCHAR(64) NOT NULL,
+  op CHAR(2) NOT NULL DEFAULT '=',
+  value VARCHAR(253) NOT NULL,
+  INDEX idx_radgroupreply_group (groupname)
+);
+CREATE TABLE IF NOT EXISTS radacct (
+  radacctid BIGINT AUTO_INCREMENT PRIMARY KEY,
+  acctsessionid VARCHAR(64) NOT NULL,
+  acctuniqueid VARCHAR(32) NOT NULL,
+  username VARCHAR(64) NOT NULL,
+  realm VARCHAR(64),
+  nasipaddress VARCHAR(15) NOT NULL,
+  nasportid VARCHAR(15),
+  nasporttype VARCHAR(32),
+  acctstarttime DATETIME,
+  acctupdatetime DATETIME,
+  acctstoptime DATETIME,
+  acctsessiontime INT,
+  acctinputoctets BIGINT,
+  acctoutputoctets BIGINT,
+  framedipaddress VARCHAR(15),
+  calledstationid VARCHAR(50),
+  callingstationid VARCHAR(50),
+  acctterminatecause VARCHAR(32),
+  servicetype VARCHAR(32),
+  framedprotocol VARCHAR(32),
+  INDEX idx_radacct_active (acctstoptime),
+  INDEX idx_radacct_username (username)
+);
+CREATE TABLE IF NOT EXISTS nas (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  nasname VARCHAR(128) NOT NULL,
+  shortname VARCHAR(32),
+  type VARCHAR(30) DEFAULT 'other',
+  ports INT,
+  secret VARCHAR(60) NOT NULL,
+  server VARCHAR(64),
+  community VARCHAR(50),
+  description VARCHAR(200)
+);
+CREATE TABLE IF NOT EXISTS radpostauth (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  username VARCHAR(64) NOT NULL,
+  pass VARCHAR(64) NOT NULL,
+  reply VARCHAR(32) NOT NULL,
+  authdate TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/backend/database/seeders/DatabaseSeeder.php
+++ b/backend/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class DatabaseSeeder extends Seeder
+{
+    public function run(): void
+    {
+        DB::table('packages')->insert([
+            [
+                'name' => 'Home 20M',
+                'download_kbps' => 20000,
+                'upload_kbps' => 5000,
+                'price' => 1500,
+                'validity_days' => 30,
+                'radius_group' => 'pkg_home_20m',
+                'radius_attributes' => json_encode([
+                    'Mikrotik-Rate-Limit' => '20M/5M',
+                    'Acct-Interim-Interval' => '300',
+                ]),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        DB::table('radgroupreply')->insert([
+            [
+                'groupname' => 'pkg_home_20m',
+                'attribute' => 'Mikrotik-Rate-Limit',
+                'op' => '=',
+                'value' => '20M/5M',
+            ],
+            [
+                'groupname' => 'pkg_home_20m',
+                'attribute' => 'Acct-Interim-Interval',
+                'op' => '=',
+                'value' => '300',
+            ],
+        ]);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\DashboardController;
+use App\Http\Controllers\Api\PackageController;
+use App\Http\Controllers\Api\PppoeClientController;
+use App\Http\Controllers\Api\NasDeviceController;
+use App\Http\Controllers\Api\RenewalController;
+use App\Http\Controllers\Api\PaymentController;
+use App\Http\Controllers\Api\OnlineSessionController;
+
+Route::post('/auth/login', [AuthController::class, 'login']);
+
+Route::middleware(['auth:sanctum'])->group(function () {
+    Route::get('/dashboard', [DashboardController::class, 'index']);
+    Route::apiResource('/packages', PackageController::class);
+    Route::apiResource('/clients', PppoeClientController::class);
+    Route::post('/clients/{client}/renew', [RenewalController::class, 'store']);
+    Route::post('/clients/{client}/disable', [PppoeClientController::class, 'disable']);
+
+    Route::apiResource('/nas-devices', NasDeviceController::class);
+    Route::apiResource('/payments', PaymentController::class)->only(['index', 'store', 'show']);
+    Route::get('/online-sessions', [OnlineSessionController::class, 'index']);
+});

--- a/docs/SETUP_UBUNTU.md
+++ b/docs/SETUP_UBUNTU.md
@@ -1,0 +1,101 @@
+# Ubuntu Server Setup (Laravel + React + FreeRADIUS + MikroTik)
+
+## 1) Install dependencies
+```bash
+sudo apt update
+sudo apt install -y nginx mysql-server php-fpm php-mysql php-xml php-mbstring php-curl php-zip composer nodejs npm freeradius freeradius-mysql
+```
+
+## 2) Database
+```sql
+CREATE DATABASE radius_manager CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER 'radius_user'@'localhost' IDENTIFIED BY 'strong_password';
+GRANT ALL PRIVILEGES ON radius_manager.* TO 'radius_user'@'localhost';
+FLUSH PRIVILEGES;
+```
+
+## 3) Backend (Laravel API)
+```bash
+cd backend
+cp .env.example .env
+composer install
+php artisan key:generate
+php artisan migrate --seed
+php artisan config:cache
+```
+
+## 4) Frontend (React + Tailwind)
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+Build output should be deployed to `/var/www/optixcom-web/frontend/dist` (or your selected web root path).
+
+## 5) Nginx configuration
+Create `/etc/nginx/sites-available/optixcom-radius-manager.conf`:
+
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    root /var/www/optixcom-web/frontend/dist;
+    index index.html;
+
+    # React SPA
+    location / {
+        try_files $uri /index.html;
+    }
+
+    # Laravel API proxy
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Deny hidden files
+    location ~ /\.|\.env {
+        deny all;
+    }
+}
+```
+
+Enable and test:
+```bash
+sudo ln -s /etc/nginx/sites-available/optixcom-radius-manager.conf /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl reload nginx
+```
+
+> For production, terminate TLS with Let's Encrypt and redirect HTTP to HTTPS.
+
+## 6) Run backend process
+For quick start:
+```bash
+cd /var/www/optixcom-web/backend
+php artisan serve --host=127.0.0.1 --port=8000
+```
+
+For production, use PHP-FPM + Nginx upstream (recommended) or Supervisor with `php artisan octane`/queue workers.
+
+## 7) FreeRADIUS SQL integration
+- In `/etc/freeradius/3.0/mods-enabled/sql`, set database credentials.
+- Ensure SQL module is enabled and used in `sites-enabled/default` and `inner-tunnel` authorize/accounting sections.
+
+```bash
+sudo systemctl restart freeradius
+sudo systemctl enable freeradius
+```
+
+## 8) MikroTik NAS setup
+```routeros
+/radius add service=ppp address=RADIUS_SERVER_IP secret=RADIUS_SECRET authentication-port=1812 accounting-port=1813
+/ppp aaa set use-radius=yes accounting=yes interim-update=5m
+```
+
+> Do **not** create `/ppp secret` entries on MikroTik.

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,0 +1,7 @@
+export const api = {
+  async getDashboard(token) {
+    const res = await fetch('/api/dashboard', { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok) throw new Error('Failed to load dashboard');
+    return res.json();
+  },
+};

--- a/frontend/src/pages/ClientsPage.jsx
+++ b/frontend/src/pages/ClientsPage.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function ClientsPage() {
+  return (
+    <section>
+      <h1 className="text-2xl font-bold mb-4">PPPoE Clients</h1>
+      <p className="text-gray-600">Create, edit, disable, delete, renew, and monitor expiry from this page.</p>
+    </section>
+  );
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export default function Dashboard({ stats }) {
+  const cards = [
+    ['Total Clients', stats.total_clients],
+    ['Active Clients', stats.active_clients],
+    ['Expired Clients', stats.expired_clients],
+    ['Disabled Clients', stats.disabled_clients],
+    ['Online PPPoE Users', stats.online_users],
+    ['Monthly Renewals', stats.monthly_renewals],
+    ['Monthly Income', `ALL ${stats.monthly_income}`],
+    ['Routers/NAS Count', stats.nas_count],
+  ];
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      {cards.map(([label, value]) => (
+        <div key={label} className="rounded-2xl shadow bg-white p-4">
+          <p className="text-sm text-gray-500">{label}</p>
+          <h2 className="text-2xl font-semibold">{value}</h2>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a production-ready architecture and starter implementation for a PPPoE RADIUS manager that uses a local Laravel API, FreeRADIUS SQL tables, and MikroTik as a NAS-only PPPoE server. 
- Centralize client and package management in the backend and synchronize credentials and groups into FreeRADIUS to avoid storing PPP secrets on routers. 
- Ship a minimal React dashboard and clients page to accelerate front-end integration and deployment.

### Description

- Update `README.md` with architecture overview and a high-level component list for Backend (Laravel), Frontend (React + Tailwind), FreeRADIUS SQL, and MikroTik behavior. 
- Add Laravel backend pieces including `PppoeClientController`, `RadiusSyncService`, Eloquent models `PppoeClient` and `Package`, API routes in `backend/routes/api.php`, and seeders in `backend/database/seeders/DatabaseSeeder.php`. 
- Add database migrations for `packages`, `pppoe_clients`, billing/logs (`payments`, `renewals`, `nas_devices`, `activity_logs`), and a migration that imports FreeRADIUS SQL from `database/schema/freeradius.sql`. 
- Add frontend starters: `frontend/src/lib/api.js`, `frontend/src/pages/Dashboard.jsx`, and `frontend/src/pages/ClientsPage.jsx`, plus an Ubuntu setup guide at `docs/SETUP_UBUNTU.md` with `php artisan migrate --seed` and FreeRADIUS integration steps.

### Testing

- No automated tests were executed as part of this change. 
- Tests and CI are not included in this PR and the next steps recommend adding feature and integration tests for the Radius sync and renewal flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe1b440f6c8324991796c67c0ad44f)